### PR TITLE
make life easier for callbacks.

### DIFF
--- a/rocks.ml
+++ b/rocks.ml
@@ -95,6 +95,14 @@ module RocksDb = struct
         (Options.t @-> string @-> ptr string_opt @-> returning t) in
     fun options name -> with_err_pointer (inner options name)
 
+  let open_db_with_wrapper options name wrapper =
+    let inner =
+      foreign
+        wrapper
+        (Options.t @-> string @-> ptr string_opt @-> returning t)
+    in
+    with_err_pointer (inner options name)
+
   let close =
     let inner =
       foreign
@@ -116,7 +124,7 @@ module RocksDb = struct
     fun t wo key k_off k_len value v_off v_len ->
       with_err_pointer
         (inner
-           t wo 
+           t wo
            (ocaml_string_start key +@ k_off) k_len
            (ocaml_string_start value +@ v_off) v_len)
 

--- a/rocks.mli
+++ b/rocks.mli
@@ -179,6 +179,7 @@ module RocksDb :
     type t
 
     val open_db : Options.t -> string -> t
+    val open_db_with_wrapper : Options.t -> string -> string -> t
     val close : t -> unit
 
     val get_slice : t -> ReadOptions.t ->


### PR DESCRIPTION
Used [in alba](https://github.com/openvstorage/alba/blob/rora/ocaml/src/rocks_store.ml#L41).
This indirection allows users to do something before returning the opened db.
