### PR TITLE
modify Makefile and myocamlbuild.ml to allow specifying location & name of rocksdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ OCAML_FIND ?= ocamlfind
 
 ROCKS_LIBDIR ?= /usr/local/lib
 ROCKS_LIB ?= rocksdb
+export ROCKS_LIB ROCKS_LIBDIR
 
 ROCKS_LINKFLAGS = \
   -lflag -cclib -lflag -Wl,-rpath=$(ROCKS_LIBDIR) \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
 OCAML_LIBDIR?=`ocamlfind printconf destdir`
 OCAML_FIND ?= ocamlfind
 
+ROCKS_LIBDIR ?= /usr/local/lib
+ROCKS_LIB ?= rocksdb
+
+ROCKS_LINKFLAGS = \
+  -lflag -cclib -lflag -Wl,-rpath=$(ROCKS_LIBDIR) \
+  -lflags -cclib,-L$(ROCKS_LIBDIR),-cclib,-l$(ROCKS_LIB)
+
 build:
-	ocamlbuild -use-ocamlfind -lflags -cclib,-lrocksdb rocks.inferred.mli rocks.cma rocks.cmxa rocks.cmxs rocks_options.inferred.mli
+	ocamlbuild -use-ocamlfind $(ROCKS_LINKFLAGS) rocks.inferred.mli rocks.cma rocks.cmxa rocks.cmxs rocks_options.inferred.mli
 
 test:
-	ocamlbuild -use-ocamlfind -lflags -cclib,-lrocksdb rocks_test.native rocks.inferred.mli rocks.cma rocks.cmxa rocks.cmxs
+	ocamlbuild -use-ocamlfind $(ROCKS_LINKFLAGS) rocks_test.native rocks.inferred.mli rocks.cma rocks.cmxa rocks.cmxs
+	./rocks_test.native
 
 clean:
 	ocamlbuild -clean
+	rm -rf aname
 
 install:
 	mkdir -p $(OCAML_LIBDIR)

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -46,6 +46,17 @@ let make_version_and_meta _ _ =
     | -1 -> git_revision
     | _  -> Printf.sprintf "%i.%i.%i" major minor patch
   in
+  let rocks_libdir =
+    try Unix.getenv "ROCKS_LIBDIR"
+    with Not_found ->
+      failwith "MUST set ROCKS_LIBDIR to build" in
+  let rocks_lib =
+    try Unix.getenv "ROCKS_LIB"
+    with Not_found ->
+      failwith "MUST set ROCKS_LIB to build" in
+  let linkopts =
+    Printf.sprintf "-cclib -Wl,-rpath=%s -cclib -L%s -cclib -l%s"
+      rocks_libdir rocks_libdir rocks_lib in
   let meta_lines = [
       "description = \"Rocksdb binding\"\n";
       Printf.sprintf "version = %S\n" clean_version;
@@ -53,7 +64,7 @@ let make_version_and_meta _ _ =
       "requires = \"ctypes ctypes.foreign\"\n";
       "archive(native) = \"rocks.cmxa\"\n";
       "archive(byte) = \"rocks.cma\"\n";
-      "linkopts = \"-cclib -lrocksdb\""
+      Printf.sprintf "linkopts = \"%s\"" linkopts ;
     ]
   in
   let write_meta = Echo (meta_lines, "META") in


### PR DESCRIPTION
Hi, I hope this is OK.  I'm starting to hack on rocksdb in the context of myrocks, and they use a pre-5.0.0 rocksdb -and- with a few changes.  This change is just to make it easy to specify the rocksdb install against which orocks is built.

It changes the makefile, and also the generated META.  I've verified that all of this works with rocksdb in nonstandard locations.
