### PR TITLE
Fix mac build issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ROCKS_LIB ?= rocksdb
 export ROCKS_LIB ROCKS_LIBDIR
 
 ROCKS_LINKFLAGS = \
-  -lflag -cclib -lflag -Wl,-rpath=$(ROCKS_LIBDIR) \
+  -lflag -cclib -lflag -Wl,-rpath,$(ROCKS_LIBDIR) \
   -lflags -cclib,-L$(ROCKS_LIBDIR),-cclib,-l$(ROCKS_LIB)
 
 build:


### PR DESCRIPTION
Building `orocksdb` on a Mac (using clang) gives me the following error:

```
...
+ ocamlfind ocamlopt -shared -cclib '-Wl,-rpath=/usr/local/lib' -cclib -L/usr/local/lib -cclib -lrocksdb -linkall -package ctypes -package ctypes.foreign rocks.cmxa -o rocks.cmxs
ld: unknown option: -rpath=/usr/local/lib
clang: error: linker command failed with exit code 1 (use -v to see invocation)
...
```

This fix is based on [this](https://stackoverflow.com/a/32400674) SO answer.